### PR TITLE
Fix scoring for scoring for old meetings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 dist/
-
 .clasprc.json
 .clasp.json
 .DS_Store

--- a/example.clasp.json
+++ b/example.clasp.json
@@ -1,4 +1,0 @@
-{
-  "scriptId": "your_script_id_here",
-  "rootDir": "./dist"
-}

--- a/src/generate-meetings.js
+++ b/src/generate-meetings.js
@@ -43,7 +43,7 @@ function getTypeBScore(person1, person2) {
       p1ExclusionData[0].indexOf(p2ExclusionData[1]) > -1 ||
       p2ExclusionData[0].indexOf(p1ExclusionData[1]) > -1
     ) {
-      return total + 20;
+      return total + 10;
     }
 
     return total;
@@ -53,7 +53,9 @@ function getTypeBScore(person1, person2) {
 }
 
 function getPastMeetingScore(person1Id, person2Id, pastMeetingsPerPerson) {
-  return pastMeetingsPerPerson[person1Id].filter(person => person === person2Id).length * 10;
+  return (
+    pastMeetingsPerPerson[person1Id].filter(meeting => meeting.includes(person2Id)).length * 10
+  );
 }
 
 function getRandomScore(person1Id, person2Id, pastMeetingsPerPerson, mostMeetingsPerPerson) {


### PR DESCRIPTION
Found out that old meetings didn't give any score due to logic error in function getPastMeetingScore(). Also lowered typeB (excludeThese) scoring from 20 to 10 (per option).